### PR TITLE
upgrade to Kotlin 2.2.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-kotlin = '2.2.0'
+kotlin = '2.2.20'
 compose-ui = '1.8.3'
-google-ksp = '2.2.0-2.0.2' # https://mvnrepository.com/artifact/com.google.devtools.ksp/com.google.devtools.ksp.gradle.plugin?repo=central
+google-ksp = '2.2.20-2.0.3' # https://mvnrepository.com/artifact/com.google.devtools.ksp/com.google.devtools.ksp.gradle.plugin?repo=central
 activity = '1.10.1'
 agp = '8.9.3'
 espresso = '3.6.1'


### PR DESCRIPTION
Kotlin 2.2.20 introduces another ABI chnage for the IR apis

The exception I was getting when upgrading to Kotlin 2.2.20:
```
e: java.lang.NoSuchMethodError: 'org.jetbrains.kotlin.ir.types.IrType org.jetbrains.kotlin.ir.types.IrTypesKt.getDefaultType(org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol)'
        at com.jeppeman.mockposable.compiler.IrUtilsKt.transformComposeArgs(IrUtils.kt:220)
        at com.jeppeman.mockposable.compiler.MockKIrGenerationExtensionKt.transformAllComposableCalls(MockKIrGenerationExtension.kt:129)
        at com.jeppeman.mockposable.compiler.MockKIrGenerationExtensionKt.access$transformAllComposableCalls(MockKIrGenerationExtension.kt:1)
        at com.jeppeman.mockposable.compiler.MockKCallTransformer.visitCall(MockKIrGenerationExtension.kt:89)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitCall(IrElementTransformerVoid.kt:299)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitCall(IrElementTransformerVoid.kt:19)
```