### PR TITLE
Kotlin 2.4.0 support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-kotlin = '2.3.20'
+kotlin = '2.4.0'
 compose-ui = '1.10.6'
-google-ksp = '2.3.6' # https://mvnrepository.com/artifact/com.google.devtools.ksp/com.google.devtools.ksp.gradle.plugin?repo=central
+google-ksp = '2.3.9' # https://mvnrepository.com/artifact/com.google.devtools.ksp/com.google.devtools.ksp.gradle.plugin?repo=central
 activity = '1.13.0'
 agp = '9.1.0'
 espresso = '3.7.0'
@@ -37,7 +37,7 @@ autoservice-annotations = { module = 'com.google.auto.service:auto-service-annot
 google-ksp = { module = 'com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin', version.ref = 'google-ksp' }
 
 # compile-testing = { module = 'com.github.tschuchortdev:kotlin-compile-testing', version = '1.5.0' }
-compile-testing = { module = 'dev.zacsweers.kctfork:core', version = '0.12.1' }
+compile-testing = { module = 'dev.zacsweers.kctfork:core', version = '0.13.0' }
 
 junit = { module = 'androidx.test.ext:junit', version = '1.1.3' }
 

--- a/mockposable/mockposable-compiler/src/main/java/com/jeppeman/mockposable/compiler/IrUtils.kt
+++ b/mockposable/mockposable-compiler/src/main/java/com/jeppeman/mockposable/compiler/IrUtils.kt
@@ -1,8 +1,5 @@
-@file:OptIn(DeprecatedForRemovalCompilerApi::class)
-
 package com.jeppeman.mockposable.compiler
 
-import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.IrElement
@@ -126,11 +123,11 @@ data class IrStatementWithParent(val statement: IrStatement, val parent: IrEleme
 fun IrCall.extractComposableCallFromBlockArg(
     name: String,
 ): IrFunctionExpression {
-    val composableBlockValueParameter = symbol.owner.valueParameters.find { valueParameter ->
+    val composableBlockValueParameter = symbol.owner.parameters.find { valueParameter ->
         valueParameter.name.asString() == name
     } ?: pluginError("Failed to find @Composable function in lambda from $name.")
 
-    val composableBlockValueArgument = getValueArgument(composableBlockValueParameter.index)
+    val composableBlockValueArgument = arguments[composableBlockValueParameter]
         ?: pluginError("No value argument found for ${composableBlockValueParameter.name}.")
 
     return composableBlockValueArgument.run {
@@ -162,13 +159,13 @@ private fun IrExpression.extractComposableLambdaInstance(
     is IrCall -> when (symbol.owner.name.asString()) {
         // If this branch is matched we found a composableLambdaInstance(key, tracked, block = @Composable { ... })
         "composableLambdaInstance", "composableLambda" -> {
-            val blockValueParameter = symbol.owner.valueParameters.find { valueParameter ->
+            val blockValueParameter = symbol.owner.parameters.find { valueParameter ->
                 valueParameter.name.asString() == composableLambdaBlockParameterName
             } ?: pluginError(
-                "Failed to find @Composable block in composableLambdaInstance from $composableLambdaBlockParameterName}. Parameter names were: ${symbol.owner.valueParameters.map { it.name }}."
+                "Failed to find @Composable block in composableLambdaInstance from $composableLambdaBlockParameterName}. Parameter names were: ${symbol.owner.parameters.map { it.name }}."
             )
 
-            val valueArgument = getValueArgument(blockValueParameter.index)
+            val valueArgument = arguments[blockValueParameter]
                 ?: pluginError("No value argument found for ${blockValueParameter.name}.")
             valueArgument.cast<IrFunctionExpression>() ?: pluginError(
                 "Assumed wrong type for value argument ${blockValueParameter.name}, expected ${IrFunctionExpression::class.java.name}, got ${valueArgument::class.java.name}."
@@ -219,11 +216,11 @@ fun IrCall.transformComposeArgs(
 
     val composerType = pluginContext.composerClassSymbol.defaultType.makeNullable()
 
-    val composerArgIndex = (0 until valueArgumentsCount)
-        .mapNotNull { index -> getValueArgument(index)?.let { index to it } }
+    val composerArgIndex = arguments.indices
+        .mapNotNull { index -> arguments[index]?.let { index to it } }
         .find { (_, arg) -> arg.type == composerType }
         ?.first
-    val composerArgMissing = symbol.owner.valueParameters.none {
+    val composerArgMissing = symbol.owner.parameters.none {
         it.type.makeNullable() == composerType
     }
 
@@ -234,20 +231,14 @@ fun IrCall.transformComposeArgs(
         )
     }
 
-    putValueArgument(
-        composerArgIndex,
-        pluginContext.buildIr(symbol) {
-            composerArgument(getValueArgument(composerArgIndex)!!)
-        }
-    )
+    arguments[composerArgIndex] = pluginContext.buildIr(symbol) {
+        composerArgument(arguments[composerArgIndex]!!)
+    }
 
     // $changed is always added as following $composer
-    putValueArgument(
-        composerArgIndex + 1,
-        pluginContext.buildIr(symbol) {
-            changedArgument(getValueArgument(composerArgIndex + 1)!!)
-        }
-    )
+    arguments[composerArgIndex + 1] = pluginContext.buildIr(symbol) {
+        changedArgument(arguments[composerArgIndex + 1]!!)
+    }
 
     val afterTransform = dumpKotlinLike()
     logger.log("Transformed $beforeTransform -> $afterTransform")

--- a/mockposable/mockposable-compiler/src/main/java/com/jeppeman/mockposable/compiler/MockKIrGenerationExtension.kt
+++ b/mockposable/mockposable-compiler/src/main/java/com/jeppeman/mockposable/compiler/MockKIrGenerationExtension.kt
@@ -1,8 +1,5 @@
-@file:OptIn(DeprecatedForRemovalCompilerApi::class)
-
 package com.jeppeman.mockposable.compiler
 
-import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
@@ -11,6 +8,7 @@ import org.jetbrains.kotlin.config.IrVerificationMode
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -72,7 +70,8 @@ private abstract class MockKCallTransformer(
         val composableBlock = expression
             .extractComposableCallFromBlockArg(composableBlockParameterName)
 
-        val mockKMatcherScope = composableBlock.function.extensionReceiverParameter
+        val mockKMatcherScope = composableBlock.function.parameters
+            .find { it.kind == IrParameterKind.ExtensionReceiver }
             ?: pluginError(
                 "Expected an extensionReceiverParameter for function ${composableBlock.function.dumpKotlinLike()}, but was null."
             )
@@ -125,14 +124,14 @@ private fun IrFunctionExpression.transformAllComposableCalls(
             { composerValueArgument ->
                 irCall(anyMatcherFunction).apply {
                     dispatchReceiver = irGet(mockKScope)
-                    putTypeArgument(0, composerValueArgument.type)
+                    typeArguments[0] = composerValueArgument.type
                 }
             },
             // Transforming $changed to any<Int>()
             { changedValueArgument ->
                 irCall(anyMatcherFunction).apply {
                     dispatchReceiver = irGet(mockKScope)
-                    putTypeArgument(0, changedValueArgument.type)
+                    typeArguments[0] = changedValueArgument.type
                 }
             },
             logger

--- a/mockposable/mockposable-compiler/src/main/java/com/jeppeman/mockposable/compiler/MockitoIrGenerationExtension.kt
+++ b/mockposable/mockposable-compiler/src/main/java/com/jeppeman/mockposable/compiler/MockitoIrGenerationExtension.kt
@@ -1,8 +1,5 @@
-@file:OptIn(DeprecatedForRemovalCompilerApi::class)
-
 package com.jeppeman.mockposable.compiler
 
-import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
@@ -104,15 +101,15 @@ private fun IrFunctionExpression.transformAllComposableCalls(
             // Transforming $composer to any<Composer?>($composer)
             { composerValueArgument ->
                 irCall(anyMatcherFunction).apply {
-                    putTypeArgument(0, composerValueArgument.type)
-                    putValueArgument(0, composerValueArgument)
+                    typeArguments[0] = composerValueArgument.type
+                    arguments[0] = composerValueArgument
                 }
             },
             // Transforming $composer to any<Int>($changed)
             { changedValueArgument ->
                 irCall(anyMatcherFunction).apply {
-                    putTypeArgument(0, changedValueArgument.type)
-                    putValueArgument(0, changedValueArgument)
+                    typeArguments[0] = changedValueArgument.type
+                    arguments[0] = changedValueArgument
                 }
             },
             logger


### PR DESCRIPTION
Adds Kotlin 2.4.0 support.

Closes #55

2.4.0 removed the deprecated IR APIs the transforms used (`getValueArgument`/`putValueArgument`/`putTypeArgument`/`valueArgumentsCount`/`valueParameters`/`extensionReceiverParameter`), so the compiler module no longer built. It also reshaped `IrGenerationExtension.Companion`, which made `registerExtensions` throw a `ClassCastException` at runtime for anyone building against 2.4.0 with a 0.18 jar.

- Migrate the transforms to the unified parameter/argument model (`arguments[…]`, `typeArguments[…]`, `parameters`, `IrParameterKind.ExtensionReceiver`).
- kotlin 2.3.20 → 2.4.0, google-ksp 2.3.6 → 2.3.9, kctfork 0.12.1 → 0.13.0 (0.12.1 passes null to the now non-null `optIn` arg and breaks the compiler tests on 2.4.0).

The `IrGenerationExtension.registerExtension(...)` call is unchanged; recompiling against 2.4.0 is enough since the crash was a binary-skew artifact.

`./gradlew :mockposable-compiler:test` passes (MockK + Mockito).

> Code assisted by Claude Code
